### PR TITLE
Modify moves table

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,6 +32,7 @@ gem 'spring',        group: :development
 group :development, :test do
   gem 'rspec-rails', '~> 3.0'
   gem "factory_girl_rails", "~> 4.0"
+  gem 'pry-rails'
 end
 
 gem 'simple_form'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -35,6 +35,7 @@ GEM
       autoprefixer-rails (>= 5.0.0.1)
       sass (>= 3.3.0)
     builder (3.2.2)
+    coderay (1.1.1)
     coffee-rails (4.0.1)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0, < 5.0)
@@ -67,6 +68,7 @@ GEM
     json (1.8.3)
     mail (2.6.4)
       mime-types (>= 1.16, < 4)
+    method_source (0.8.2)
     mime-types (3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2016.0521)
@@ -74,6 +76,12 @@ GEM
     multi_json (1.12.1)
     orm_adapter (0.5.0)
     pg (0.19.0)
+    pry (0.10.4)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+      slop (~> 3.4)
+    pry-rails (0.3.4)
+      pry (>= 0.9.10)
     rack (1.5.5)
     rack-test (0.6.3)
       rack (>= 1.0)
@@ -126,6 +134,7 @@ GEM
     simple_form (3.2.1)
       actionpack (> 4, < 5.1)
       activemodel (> 4, < 5.1)
+    slop (3.6.0)
     spring (1.7.2)
     sprockets (2.11.0)
       hike (~> 1.2)
@@ -160,6 +169,7 @@ DEPENDENCIES
   jbuilder (~> 2.0)
   jquery-rails
   pg
+  pry-rails
   rails (= 4.1.9)
   rspec-rails (~> 3.0)
   sass-rails

--- a/app/models/helpers/piece_helper.rb
+++ b/app/models/helpers/piece_helper.rb
@@ -60,10 +60,14 @@ module PieceHelper
   end
 
   def record_move(row_destination, col_destination)
-    # TODO: improve this simple move recording.
-    # Generate string including piece id, current position and destination position.
-    move_string = "#{self.id}, r#{self.row},c#{self.column},r#{row_destination},c#{col_destination}"
     # Record the game leveraging the relationship of piece->game->moves
-    self.game.moves.create(is_black: self.is_black, move_string: move_string)
+    self.game.moves.create(
+      is_black: self.is_black,
+      piece_id: self.id,
+      start_row: self.row,
+      start_column: self.column,
+      end_row: row_destination,
+      end_column: col_destination,
+      )
   end
 end

--- a/db/migrate/20170129223636_alter_moves_table.rb
+++ b/db/migrate/20170129223636_alter_moves_table.rb
@@ -1,0 +1,10 @@
+class AlterMovesTable < ActiveRecord::Migration
+  def change
+    remove_column :moves, :move_string, :string
+    add_column :moves, :piece_id, :integer
+    add_column :moves, :start_row, :integer
+    add_column :moves, :start_column, :integer
+    add_column :moves, :end_row, :integer
+    add_column :moves, :end_column, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170118160230) do
+ActiveRecord::Schema.define(version: 20170129223636) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -49,10 +49,14 @@ ActiveRecord::Schema.define(version: 20170118160230) do
   create_table "moves", force: true do |t|
     t.integer  "game_id"
     t.boolean  "is_black"
-    t.string   "move_string"
     t.integer  "time_sec_lapse"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.integer  "piece_id"
+    t.integer  "start_row"
+    t.integer  "start_column"
+    t.integer  "end_row"
+    t.integer  "end_column"
   end
 
   add_index "moves", ["game_id"], name: "index_moves_on_game_id", using: :btree

--- a/spec/models/piece_spec.rb
+++ b/spec/models/piece_spec.rb
@@ -140,4 +140,19 @@ RSpec.describe Piece, type: :model do
       expect(moving_piece.is_obstructed_diagonally?(3,3)).to eq false
     end
   end
+
+  describe 'move_to' do
+    it 'should record the move in the moves table' do
+      game = FactoryGirl.create(:game)
+      pawn = FactoryGirl.create(:pawn, game_id: game.id)
+      pawn.move_to(2,1)
+
+      move = game.moves.last
+      expect(move.piece_id).to eq pawn.id
+      expect(move.start_row).to eq 1
+      expect(move.start_column).to eq 1
+      expect(move.end_row).to eq 2
+      expect(move.end_column).to eq 1
+    end
+  end
 end


### PR DESCRIPTION
# Modify moves table
In order to better facilitate moves like castling and en passant I have added a few additional fields to allow us to determine if a piece has moved or not. 
- Adds additional integer fields to track start and end row / column pairs.
- Adds test to piece spec to confirm proper move recording.
- Adds pry gem to better facilitate debugging (this something I have been personally adding and removing to help me test. Figured it's about time we just add it in to the repo in case anyone else wants to use it.)