### PR TITLE
Capture logic

### DIFF
--- a/app/models/helpers/piece_helper.rb
+++ b/app/models/helpers/piece_helper.rb
@@ -72,10 +72,12 @@ module PieceHelper
   end
 
   def capturable?(row_destination, col_destination)
+    # Return true if an opponent piece exists at the specific location
     return self.game.pieces.active.exists?(row: row_destination, column:col_destination, is_black: !self.is_black)
   end
 
   def capture_piece(row_destination, col_destination)
+    # Select opponent piece and set captured field to true
     piece = self.game.pieces.active.find_by(row: row_destination, column: col_destination, is_black: !self.is_black)
     piece.update_attribute :captured, true
   end

--- a/app/models/helpers/piece_helper.rb
+++ b/app/models/helpers/piece_helper.rb
@@ -70,4 +70,13 @@ module PieceHelper
       end_column: col_destination,
       )
   end
+
+  def capturable?(row_destination, col_destination)
+    return self.game.pieces.active.exists?(row: row_destination, column:col_destination, is_black: !self.is_black)
+  end
+
+  def capture_piece(row_destination, col_destination)
+    piece = self.game.pieces.active.find_by(row: row_destination, column: col_destination, is_black: !self.is_black)
+    piece.update_attribute :captured, true
+  end
 end

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -1,4 +1,7 @@
 class Piece < ActiveRecord::Base
+  scope :active, -> { where captured: false }
+  scope :captured, -> { where captured: true }
+
   require_relative 'helpers/piece_helper'
   include PieceHelper
 

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -14,7 +14,8 @@ class Piece < ActiveRecord::Base
     return false
   end
 
-  # Utilize helper methods to check validity of move, make the move, and record the move.
+  # Utilize helper methods to check validity of move, make and record the move,
+  # and capture if appropriate.
   def move_to(row_destination, col_destination)
     # Capture piece located at target location if exists
     capture_piece(row_destination, col_destination) if capturable?(row_destination, col_destination)

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -1,6 +1,6 @@
 class Piece < ActiveRecord::Base
-  scope :active, -> { where captured: false }
-  scope :captured, -> { where captured: true }
+  scope :active, -> { where(captured: false) }
+  scope :captured, -> { where(captured: true) }
 
   require_relative 'helpers/piece_helper'
   include PieceHelper
@@ -16,8 +16,18 @@ class Piece < ActiveRecord::Base
 
   # Utilize helper methods to check validity of move, make the move, and record the move.
   def move_to(row_destination, col_destination)
+    # Capture piece located at target location if exists
+    if capturable?(row_destination, col_destination)
+      piece = self.game.pieces.active.find_by(row: row_destination, column: col_destination, is_black: !self.is_black)
+      piece.update_attribute :captured, true
+    end
     # If all checks pass, record the move, update piece position, and deselect the peice.
     self.record_move(row_destination, col_destination)
     self.update_attributes(column: col_destination, row: row_destination, is_selected: false)
+  end
+
+  def capturable?(row_destination, col_destination)
+    # binding.pry
+    return self.game.pieces.active.exists?(row: row_destination, column:col_destination, is_black: !self.is_black)
   end
 end

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -17,17 +17,10 @@ class Piece < ActiveRecord::Base
   # Utilize helper methods to check validity of move, make the move, and record the move.
   def move_to(row_destination, col_destination)
     # Capture piece located at target location if exists
-    if capturable?(row_destination, col_destination)
-      piece = self.game.pieces.active.find_by(row: row_destination, column: col_destination, is_black: !self.is_black)
-      piece.update_attribute :captured, true
-    end
+    capture_piece(row_destination, col_destination) if capturable?(row_destination, col_destination)
+
     # If all checks pass, record the move, update piece position, and deselect the peice.
     self.record_move(row_destination, col_destination)
     self.update_attributes(column: col_destination, row: row_destination, is_selected: false)
-  end
-
-  def capturable?(row_destination, col_destination)
-    # binding.pry
-    return self.game.pieces.active.exists?(row: row_destination, column:col_destination, is_black: !self.is_black)
   end
 end

--- a/db/migrate/20170130021449_alter_piece_add_capture_column.rb
+++ b/db/migrate/20170130021449_alter_piece_add_capture_column.rb
@@ -1,0 +1,5 @@
+class AlterPieceAddCaptureColumn < ActiveRecord::Migration
+  def change
+    add_column :pieces, :captured, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170129223636) do
+ActiveRecord::Schema.define(version: 20170130021449) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -70,6 +70,7 @@ ActiveRecord::Schema.define(version: 20170129223636) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.boolean  "is_selected"
+    t.boolean  "captured"
   end
 
   add_index "pieces", ["game_id"], name: "index_pieces_on_game_id", using: :btree

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -14,6 +14,7 @@ FactoryGirl.define do
       column 1
       is_black true
       type type.to_s.capitalize
+      captured false
     end
   end
 

--- a/spec/models/piece_spec.rb
+++ b/spec/models/piece_spec.rb
@@ -154,5 +154,35 @@ RSpec.describe Piece, type: :model do
       expect(move.end_row).to eq 2
       expect(move.end_column).to eq 1
     end
+
+    it 'should set opponent piece to captured if capturable' do
+      game = FactoryGirl.create(:game)
+      black = FactoryGirl.create(:pawn, game_id: game.id)
+      white = FactoryGirl.create(:pawn, game_id: game.id, row: 2, column: 2, is_black: false)
+
+      expect(white.captured).to eq false
+
+      black.move_to(2,2)
+      white.reload
+      expect(white.captured).to eq true
+    end
+  end
+
+  describe "capture_piece" do
+    it "should return true target square contains opponet piece" do
+      game = FactoryGirl.create(:game)
+      moving_piece = FactoryGirl.create(:pawn, row: 8, column: 8, game_id: game.id)
+      opponent_piece = FactoryGirl.create(:pawn, row: 7, column: 7, is_black:false ,game_id: game.id)
+
+      expect(moving_piece.capturable?(7,7)).to eq true
+    end
+
+    it "should return false if target location contains same color piece" do
+      game = FactoryGirl.create(:game)
+      moving_piece = FactoryGirl.create(:pawn, game_id: game.id)
+      same_color_piece = FactoryGirl.create(:pawn, row: 2, column: 2, game_id: game.id)
+
+      expect(moving_piece.capturable?(2,2)).to eq false
+    end
   end
 end


### PR DESCRIPTION
# Adds capture logic to app
I took the work that Ryan and I did and am reopening a separate pull request to get these changes merged in without the secrets in the previous PR. Changes include the following.
- Add captured field to piece table
- Add capturable? and capture_piece methods to handle the capturing of opponent pieces
- Calls the capture_piece method inside of move_to if capturable? returns true
- Adds scopes to piece model to allow for easier access to appropriate data
- Modifies the specs to reflect new implementation

Please let me know what you think. Once this gets merged in I'll be able to finish up my method to check for check and get it up as another PR.