### PR TITLE
Implement castling

### DIFF
--- a/app/controllers/pieces_controller.rb
+++ b/app/controllers/pieces_controller.rb
@@ -15,12 +15,9 @@ class PiecesController < ApplicationController
   end
 
   def update
-    if is_actual_move?(params[:row], params[:column])
+    if current_piece.valid_move?(params[:row].to_i, params[:column].to_i)
       current_piece.move_to(params[:row], params[:column])
-      redirect_to game_path(current_piece.game)
-    else
-      # This will need additional game logic to not switch turns if not a real move.
-      redirect_to game_path(current_piece.game)
+      render json: current_piece
     end
   end
 

--- a/app/helpers/games_helper.rb
+++ b/app/helpers/games_helper.rb
@@ -23,7 +23,8 @@ module GamesHelper
   def render_piece_in_square(row, col, piece)
     content_tag(
       :td,
-      content_tag(:div, raw(select_html_symbol(piece)), data: { 'piece-color' => piece_color(piece) }, class: 'contains-piece'),
+      content_tag(:div, raw(select_html_symbol(piece)), data: { 'piece-color' => piece_color(piece) },
+      class: 'contains-piece', id: piece.id),
       class: square_color(row, col),
       id: "square-#{row}-#{col}",
     )

--- a/app/models/bishop.rb
+++ b/app/models/bishop.rb
@@ -1,17 +1,15 @@
 class Bishop < Piece
   include PieceHelper
 
-  def valid_move?(row_dest_int, column_dest_int)
-    if row_dest_int < 1 || row_dest_int > 8 ||
-       column_dest_int < 1 || column_dest_int > 8
-      return false
-    end
+  def valid_move?(row_destination, col_destination)
+    # check if move to outside chessboard
+    return false if !super
 
-    col_diff = self.column - column_dest_int
-    row_diff = self.row - row_dest_int
+    col_diff = self.column - col_destination
+    row_diff = self.row - row_destination
     # invalid if not on diagonal lines or obstructed diagonally
     if col_diff.abs != row_diff.abs ||
-       is_obstructed_diagonally?(row_dest_int, column_dest_int)
+       is_obstructed_diagonally?(row_destination, col_destination)
       return false
     end
 

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -6,28 +6,28 @@ class Game < ActiveRecord::Base
 
   def populate_game!
     8.times do |n|
-      self.pieces.create(type: 'Pawn', row: 2, is_black: false, column: n + 1)
-      self.pieces.create(type: 'Pawn', row: 7, is_black: true, column: n + 1)
+      self.pieces.create(type: 'Pawn', row: 2, is_black: false, captured: false, column: n + 1)
+      self.pieces.create(type: 'Pawn', row: 7, is_black: true, captured: false, column: n + 1)
     end
 
     [1,8].each do |n|
-      self.pieces.create(type: 'Rook', row: 1, is_black: false, column: n)
-      self.pieces.create(type: 'Rook', row: 8, is_black: true, column: n)
+      self.pieces.create(type: 'Rook', row: 1, is_black: false, captured: false, column: n)
+      self.pieces.create(type: 'Rook', row: 8, is_black: true, captured: false, column: n)
     end
 
     [2,7].each do |n|
-      self.pieces.create(type: 'Knight', row: 1, is_black: false, column: n)
-      self.pieces.create(type: 'Knight', row: 8, is_black: true, column: n)
+      self.pieces.create(type: 'Knight', row: 1, is_black: false, captured: false, column: n)
+      self.pieces.create(type: 'Knight', row: 8, is_black: true, captured: false, column: n)
     end
 
     [3,6].each do |n|
-      self.pieces.create(type: 'Bishop', row: 1, is_black: false, column: n)
-      self.pieces.create(type: 'Bishop', row: 8, is_black: true, column: n)
+      self.pieces.create(type: 'Bishop', row: 1, is_black: false, captured: false, column: n)
+      self.pieces.create(type: 'Bishop', row: 8, is_black: true, captured: false, column: n)
     end
 
-    self.pieces.create(type: 'Queen', row: 1, is_black: false, column: 4)
-    self.pieces.create(type: 'Queen', row: 8, is_black: true, column: 4)
-    self.pieces.create(type: 'King', row: 1, is_black: false, column: 5)
-    self.pieces.create(type: 'King', row: 8, is_black: true, column: 5)
+    self.pieces.create(type: 'Queen', row: 1, is_black: false, captured: false, column: 4)
+    self.pieces.create(type: 'Queen', row: 8, is_black: true, captured: false, column: 4)
+    self.pieces.create(type: 'King', row: 1, is_black: false, captured: false, column: 5)
+    self.pieces.create(type: 'King', row: 8, is_black: true, captured: false, column: 5)
   end
 end

--- a/app/models/helpers/piece_helper.rb
+++ b/app/models/helpers/piece_helper.rb
@@ -9,9 +9,9 @@ module PieceHelper
     end_column = col_destination + (incrementing ? -1 : 1)
 
     if incrementing
-      self.game.pieces.where(row: self.row, column: (start_column..end_column)).exists?
+      self.game.pieces.active.where(row: self.row, column: (start_column..end_column)).exists?
     else
-      self.game.pieces.where(row: self.row, column: (end_column..start_column)).exists?
+      self.game.pieces.active.where(row: self.row, column: (end_column..start_column)).exists?
     end
   end
 
@@ -25,9 +25,9 @@ module PieceHelper
     end_row = row_destination + (incrementing ? -1 : 1)
 
     if incrementing
-      self.game.pieces.where(column: self.column, row: (start_row..end_row)).exists?
+      self.game.pieces.active.where(column: self.column, row: (start_row..end_row)).exists?
     else
-      self.game.pieces.where(column: self.column, row: (end_row..start_row)).exists?
+      self.game.pieces.active.where(column: self.column, row: (end_row..start_row)).exists?
     end
   end
 
@@ -36,7 +36,7 @@ module PieceHelper
       return false
     end
 
-    pieces = self.game.pieces
+    pieces = self.game.pieces.active
 
     # Establish which x and y direction piece is moving
     row_increment = self.row < row_destination ? 1 : -1

--- a/app/models/helpers/piece_helper.rb
+++ b/app/models/helpers/piece_helper.rb
@@ -59,6 +59,10 @@ module PieceHelper
     return false
   end
 
+  def has_same_piece_color(row_destination, col_destination)
+    return self.game.pieces.active.exists?(row: row_destination, column:col_destination, is_black: self.is_black)
+  end
+
   def record_move(row_destination, col_destination)
     # Record the game leveraging the relationship of piece->game->moves
     self.game.moves.create(
@@ -79,6 +83,6 @@ module PieceHelper
   def capture_piece(row_destination, col_destination)
     # Select opponent piece and set captured field to true
     piece = self.game.pieces.active.find_by(row: row_destination, column: col_destination, is_black: !self.is_black)
-    piece.update_attribute :captured, true
+    piece.update_attributes(captured: true)
   end
 end

--- a/app/models/helpers/piece_helper.rb
+++ b/app/models/helpers/piece_helper.rb
@@ -59,7 +59,7 @@ module PieceHelper
     return false
   end
 
-  def has_same_piece_color(row_destination, col_destination)
+  def has_same_piece_color?(row_destination, col_destination)
     return self.game.pieces.active.exists?(row: row_destination, column:col_destination, is_black: self.is_black)
   end
 

--- a/app/models/king.rb
+++ b/app/models/king.rb
@@ -38,6 +38,8 @@ class King < Piece
   # If a king is not castling, call super
   def move_to(row_destination, col_destination)
     if can_castle?(row_destination, col_destination)
+      rook = self.game.pieces.active.find_by(row: row_destination, column: col_destination)
+
       # Determine if the king is castling left or right
       direction = col_destination > self.column ? 1 : -1
 
@@ -47,10 +49,13 @@ class King < Piece
 
       # Update the king and rook using these newly found columns
       self.update_attributes(column: king_column)
-      self.game.pieces.active.find_by(
-        row: row_destination,
-        column: col_destination
-      ).update_attributes(column: rook_column)
+      rook.update_attributes(column: rook_column)
+
+      # Record the moves. This will end up looking like two consecutive moves
+      # due to how table implementation. Nice to have would be a figuring out
+      # how to record this specifically as a castle move.
+      self.record_move(row_destination, king_column)
+      rook.record_move(row_destination, rook_column)
     else
       super
     end

--- a/app/models/king.rb
+++ b/app/models/king.rb
@@ -14,7 +14,12 @@ class King < Piece
     return false
   end
 
-  def can_castle?(target_rook)
+  def can_castle?(row_destination, col_destination)
+    # Determine if there is a rook at the end of the board
+    # Return false if there isn't
+    target_rook = self.game.pieces.active.find_by(row: row_destination, column: col_destination, type: 'Rook')
+    return false unless target_rook
+
     # Grab the current moves that have been made within a game.
     # Return false if either the king or rook have already moved.
     moves = self.game.moves

--- a/app/models/king.rb
+++ b/app/models/king.rb
@@ -12,8 +12,17 @@ class King < Piece
     return false
   end
 
-  def can_castle?()
+  def can_castle?(target_rook)
+    # Grab the current moves that have been made within a game.
+    # Return false if either the king or rook have already moved.
+    moves = self.game.moves
+    return false if moves.exists?(piece_id: self.id) || moves.exists?(piece_id: target_rook.id)
 
+    # Return fasle if there is a piece between the king and rook
+    return false if is_obstructed?(target_rook.row, target_rook.column)
+
+    # Return true if neither of the above tests fail
+    return true
   end
 
   def castle(row_destination, col_destination)

--- a/app/models/king.rb
+++ b/app/models/king.rb
@@ -14,4 +14,11 @@ class King < Piece
     return false
   end
 
+  def can_castle?()
+
+  end
+
+  def castle(row_destination, col_destination)
+
+  end
 end

--- a/app/models/king.rb
+++ b/app/models/king.rb
@@ -1,10 +1,12 @@
 class King < Piece
 
   def valid_move?(row_destination, col_destination)
+    # Check for possible castle move first to avoid failure due to
+    # has_same_piece_color? check.
+    return true if can_castle?(row_destination, col_destination)
+
     # check if move to outside chessboard
     return false if !super
-
-    return true if can_castle?(row_destination, col_destination)
 
     row_diff = (self.row - row_destination).abs
     col_diff = (self.column - col_destination).abs

--- a/app/models/king.rb
+++ b/app/models/king.rb
@@ -36,6 +36,8 @@ class King < Piece
   # If a king is not castling, call super
   def move_to(row_destination, col_destination)
     if can_castle?(row_destination, col_destination)
+      rook = self.game.pieces.active.find_by(row: row_destination, column: col_destination)
+
       # Determine if the king is castling left or right
       direction = col_destination > self.column ? 1 : -1
 
@@ -45,10 +47,13 @@ class King < Piece
 
       # Update the king and rook using these newly found columns
       self.update_attributes(column: king_column)
-      self.game.pieces.active.find_by(
-        row: row_destination,
-        column: col_destination
-      ).update_attributes(column: rook_column)
+      rook.update_attributes(column: rook_column)
+
+      # Record the moves. This will end up looking like two consecutive moves
+      # due to how table implementation. Nice to have would be a figuring out
+      # how to record this specifically as a castle move.
+      self.record_move(row_destination, king_column)
+      rook.record_move(row_destination, rook_column)
     else
       super
     end

--- a/app/models/king.rb
+++ b/app/models/king.rb
@@ -12,7 +12,12 @@ class King < Piece
     return false
   end
 
-  def can_castle?(target_rook)
+  def can_castle?(row_destination, col_destination)
+    # Determine if there is a rook at the end of the board
+    # Return false if there isn't
+    target_rook = self.game.pieces.active.find_by(row: row_destination, column: col_destination, type: 'Rook')
+    return false unless target_rook
+
     # Grab the current moves that have been made within a game.
     # Return false if either the king or rook have already moved.
     moves = self.game.moves

--- a/app/models/king.rb
+++ b/app/models/king.rb
@@ -4,6 +4,8 @@ class King < Piece
     # check if move to outside chessboard
     return false if !super
 
+    return true if can_castle?(row_destination, col_destination)
+
     row_diff = (self.row - row_destination).abs
     col_diff = (self.column - col_destination).abs
 
@@ -32,7 +34,25 @@ class King < Piece
     return true
   end
 
-  def castle(row_destination, col_destination)
+  # If a king is castling, do not call super
+  # If a king is not castling, call super
+  def move_to(row_destination, col_destination)
+    if can_castle?(row_destination, col_destination)
+      # Determine if the king is castling left or right
+      direction = col_destination > self.column ? 1 : -1
 
+      # Using direction, determine what row the king and rook belong on
+      king_column = self.column + (2 * direction)
+      rook_column = king_column + (1 * (direction * -1))
+
+      # Update the king and rook using these newly found columns
+      self.update_attributes(column: king_column)
+      self.game.pieces.active.find_by(
+        row: row_destination,
+        column: col_destination
+      ).update_attributes(column: rook_column)
+    else
+      super
+    end
   end
 end

--- a/app/models/king.rb
+++ b/app/models/king.rb
@@ -1,15 +1,17 @@
 class King < Piece
 
   def valid_move?(row_destination, col_destination)
-    
+    # check if move to outside chessboard
+    return false if !super
+
     row_diff = (self.row - row_destination).abs
     col_diff = (self.column - col_destination).abs
-    
+
     if (row_diff <= 1) && (col_diff <= 1)
       return true
     end
-      
-    return false 
+
+    return false
   end
-  
+
 end

--- a/app/models/king.rb
+++ b/app/models/king.rb
@@ -14,8 +14,17 @@ class King < Piece
     return false
   end
 
-  def can_castle?()
+  def can_castle?(target_rook)
+    # Grab the current moves that have been made within a game.
+    # Return false if either the king or rook have already moved.
+    moves = self.game.moves
+    return false if moves.exists?(piece_id: self.id) || moves.exists?(piece_id: target_rook.id)
 
+    # Return fasle if there is a piece between the king and rook
+    return false if is_obstructed?(target_rook.row, target_rook.column)
+
+    # Return true if neither of the above tests fail
+    return true
   end
 
   def castle(row_destination, col_destination)

--- a/app/models/king.rb
+++ b/app/models/king.rb
@@ -1,15 +1,22 @@
 class King < Piece
 
   def valid_move?(row_destination, col_destination)
-    
+
     row_diff = (self.row - row_destination).abs
     col_diff = (self.column - col_destination).abs
-    
+
     if (row_diff <= 1) && (col_diff <= 1)
       return true
     end
-      
-    return false 
+
+    return false
   end
-  
+
+  def can_castle?()
+
+  end
+
+  def castle(row_destination, col_destination)
+
+  end
 end

--- a/app/models/king.rb
+++ b/app/models/king.rb
@@ -2,6 +2,8 @@ class King < Piece
 
   def valid_move?(row_destination, col_destination)
 
+    return true if can_castle?(row_destination, col_destination)
+
     row_diff = (self.row - row_destination).abs
     col_diff = (self.column - col_destination).abs
 
@@ -30,7 +32,25 @@ class King < Piece
     return true
   end
 
-  def castle(row_destination, col_destination)
+  # If a king is castling, do not call super
+  # If a king is not castling, call super
+  def move_to(row_destination, col_destination)
+    if can_castle?(row_destination, col_destination)
+      # Determine if the king is castling left or right
+      direction = col_destination > self.column ? 1 : -1
 
+      # Using direction, determine what row the king and rook belong on
+      king_column = self.column + (2 * direction)
+      rook_column = king_column + (1 * (direction * -1))
+
+      # Update the king and rook using these newly found columns
+      self.update_attributes(column: king_column)
+      self.game.pieces.active.find_by(
+        row: row_destination,
+        column: col_destination
+      ).update_attributes(column: rook_column)
+    else
+      super
+    end
   end
 end

--- a/app/models/knight.rb
+++ b/app/models/knight.rb
@@ -1,5 +1,8 @@
 class Knight < Piece
   def valid_move?(row_destination, col_destination)
+    # check if move to outside chessboard
+    return false if !super
+
     row_diff = (self.row - row_destination).abs
     col_diff = (self.column - col_destination).abs
 

--- a/app/models/pawn.rb
+++ b/app/models/pawn.rb
@@ -1,5 +1,8 @@
 class Pawn < Piece
   def valid_move?(row_destination, col_destination)
+    # check if move to outside chessboard
+    return false if !super
+
     # Check if move destination is obstructed by another piece
     return false if is_obstructed?(row_destination, col_destination)
 

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -10,14 +10,14 @@ class Piece < ActiveRecord::Base
   def valid_move?(row_destination, col_destination)
     # check if move to outside chessboard
     if row_destination < 1 || row_destination > 8 ||
-       col_destination < 1 || col_destination > 8
+       col_destination < 1 || col_destination > 8 ||
+       has_same_piece_color(row_destination, col_destination)
       return false
     end
     return true
   end
 
   def is_obstructed?(row_destination, col_destination)
-    return true if has_same_piece_color(row_destination, col_destination)
     return true if is_obstructed_horizontally?(row_destination, col_destination)
     return true if is_obstructed_vertically?(row_destination, col_destination)
     return true if is_obstructed_diagonally?(row_destination, col_destination)

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -7,6 +7,15 @@ class Piece < ActiveRecord::Base
 
   belongs_to :game
 
+  def valid_move?(row_destination, col_destination)
+    # check if move to outside chessboard
+    if row_destination < 1 || row_destination > 8 ||
+       col_destination < 1 || col_destination > 8
+      return false
+    end
+    return true
+  end
+
   def is_obstructed?(row_destination, col_destination)
     return true if is_obstructed_horizontally?(row_destination, col_destination)
     return true if is_obstructed_vertically?(row_destination, col_destination)

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -11,7 +11,7 @@ class Piece < ActiveRecord::Base
     # check if move to outside chessboard
     if row_destination < 1 || row_destination > 8 ||
        col_destination < 1 || col_destination > 8 ||
-       has_same_piece_color(row_destination, col_destination)
+       has_same_piece_color?(row_destination, col_destination)
       return false
     end
     return true

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -17,6 +17,7 @@ class Piece < ActiveRecord::Base
   end
 
   def is_obstructed?(row_destination, col_destination)
+    return true if has_same_piece_color(row_destination, col_destination)
     return true if is_obstructed_horizontally?(row_destination, col_destination)
     return true if is_obstructed_vertically?(row_destination, col_destination)
     return true if is_obstructed_diagonally?(row_destination, col_destination)

--- a/app/models/rook.rb
+++ b/app/models/rook.rb
@@ -1,7 +1,10 @@
 class Rook < Piece
 
   def valid_move?(row_destination, col_destination)
-    #first check for obstruction
+    # check if move to outside chessboard
+    return false if !super
+
+    #check for obstruction
     if is_obstructed?(row_destination, col_destination)
       return false
     end

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -12,7 +12,7 @@
             <tr id="row-<%= row %>" class="row">
               <td class="coordinate"><%= row %></td>
               <% 1.upto(8).each do |col| %>
-                <% piece = @game.pieces.find_by(column: col, row: row, captured: false) %>
+                <% piece = @game.pieces.active.find_by(column: col, row: row) %>
                 <% unless piece %>
                   <%= render_empty_square(row, col) %>
                 <% else %>

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -12,7 +12,7 @@
             <tr id="row-<%= row %>" class="row">
               <td class="coordinate"><%= row %></td>
               <% 1.upto(8).each do |col| %>
-                <% piece = @game.pieces.find_by(column: col, row: row) %>
+                <% piece = @game.pieces.find_by(column: col, row: row, captured: false) %>
                 <% unless piece %>
                   <%= render_empty_square(row, col) %>
                 <% else %>
@@ -47,23 +47,29 @@ $(function() {
     // FIXME: This function does not check for valid move.
     //        It does not update database.
     drop: function(event, ui){
+      // get selected piece's and square's attributes
       let piece_div = ui.draggable;
       let square_div = $(this);
-      console.log(square_div.children().data('piece-color'));
-      // remove any piece of different color in the square
-      if (square_div.text().length != 0 &&
-        square_div.children().data('piece-color') != piece_div.data('piece-color')) {
+      var piece_id = piece_div.attr('id');
+      var square_id = square_div.attr('id');
+      var square_info = square_id.split('-');
+
+      // try update the piece to the new location
+      $.post("/pieces/" + piece_id, {
+        _method: "PUT",
+        row: square_info[1],
+        column: square_info[2]
+      }).success(function(data) {
+        // upon successful move, clear the destination square
+        if (square_div.text().length != 0) {
           square_div.children().hide('slow');
           square_div.empty();
-      }
-
-      // reset the selected piece position relative to the square
-      piece_div.css({left: 0, top: 0});
-
-      // only add piece into square if empty
-      if (square_div.text().length == 0) {
+        }
+        // and add the piece in
         square_div.append(piece_div);
-      }
+      });
+      // reset the piece position relative to the square
+      piece_div.css({left: 0, top: 0});
     }
   });
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -28,6 +28,24 @@ ActiveRecord::Schema.define(version: 20170130021449) do
   add_index "games", ["black_player_id"], name: "index_games_on_black_player_id", using: :btree
   add_index "games", ["white_player_id"], name: "index_games_on_white_player_id", using: :btree
 
+  create_table "identities", force: true do |t|
+    t.integer  "user_id"
+    t.string   "provider"
+    t.string   "accesstoken"
+    t.string   "refreshtoken"
+    t.string   "uid"
+    t.string   "name"
+    t.string   "email"
+    t.string   "nickname"
+    t.string   "image"
+    t.string   "phone"
+    t.string   "urls"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  add_index "identities", ["user_id"], name: "index_identities_on_user_id", using: :btree
+
   create_table "moves", force: true do |t|
     t.integer  "game_id"
     t.boolean  "is_black"
@@ -74,5 +92,23 @@ ActiveRecord::Schema.define(version: 20170130021449) do
 
   add_index "players", ["email"], name: "index_players_on_email", unique: true, using: :btree
   add_index "players", ["reset_password_token"], name: "index_players_on_reset_password_token", unique: true, using: :btree
+
+  create_table "users", force: true do |t|
+    t.string   "email",                  default: "", null: false
+    t.string   "encrypted_password",     default: "", null: false
+    t.string   "reset_password_token"
+    t.datetime "reset_password_sent_at"
+    t.datetime "remember_created_at"
+    t.integer  "sign_in_count",          default: 0,  null: false
+    t.datetime "current_sign_in_at"
+    t.datetime "last_sign_in_at"
+    t.inet     "current_sign_in_ip"
+    t.inet     "last_sign_in_ip"
+    t.datetime "created_at",                          null: false
+    t.datetime "updated_at",                          null: false
+  end
+
+  add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree
+  add_index "users", ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
 
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -4,6 +4,7 @@ FactoryGirl.define do
     row 1
     column 1
     is_black true
+    captured false
   end
 
   types = [:king, :queen, :rook, :knight, :bishop, :pawn]

--- a/spec/models/king_spec.rb
+++ b/spec/models/king_spec.rb
@@ -30,4 +30,31 @@ RSpec.describe King, type: :model do
       expect(king.valid_move?(7,5)).to eq false
     end
   end
+
+  describe "can_castle?()" do
+    before :each do
+      @game = FactoryGirl.create(:game)
+      @king = FactoryGirl.create(:king, game_id: @game.id, row: 8, column: 5)
+      @rook = FactoryGirl.create(:rook, game_id: @game.id, row: 8, column: 1)
+    end
+
+    it "should return true if king and rook have not moved" do
+      expect(@king.can_castle? @rook).to eq true
+    end
+
+    it "should return false if king has already moved" do
+      @king.move_to(8,4)
+      expect(@king.can_castle? @rook).to eq false
+    end
+
+    it "should return false if rook has already moved" do
+      @rook.move_to(8,2)
+      expect(@king.can_castle? @rook).to eq false
+    end
+
+    it "should return false if a piece is between the king and rook" do
+      obstructing_piece = FactoryGirl.create(:knight, game_id: @game.id, row: 8, column: 2)
+      expect(@king.can_castle? @rook).to eq false
+    end
+  end
 end

--- a/spec/models/king_spec.rb
+++ b/spec/models/king_spec.rb
@@ -62,4 +62,39 @@ RSpec.describe King, type: :model do
       expect(@king.can_castle? 8, 1).to eq false
     end
   end
+
+  describe "move_to()" do
+    before :each do
+      @game = FactoryGirl.create(:game)
+      @king = FactoryGirl.create(:king, game_id: @game.id, row: 8, column: 5)
+      @left_rook = FactoryGirl.create(:rook, game_id: @game.id, row: 8, column: 1)
+      @right_rook = FactoryGirl.create(:rook, game_id: @game.id, row: 8, column: 8)
+    end
+
+    it 'should call super if king is not castling' do
+      @king.move_to 8,4
+      @king.reload
+
+      expect(@king.row).to eq 8
+      expect(@king.column).to eq 4
+    end
+
+    it 'should move king two squares left and rook one square to its right' do
+      @king.move_to 8,1
+      @king.reload
+      @left_rook.reload
+
+      expect([@king.row, @king.column]).to eq [8,3]
+      expect([@left_rook.row, @left_rook.column]).to eq [8,4]
+    end
+
+    it 'should move king two squares right and rook one square to its left' do
+      @king.move_to 8,8
+      @king.reload
+      @right_rook.reload
+
+      expect([@king.row, @king.column]).to eq [8,7]
+      expect([@right_rook.row, @right_rook.column]).to eq [8,6]
+    end
+  end
 end

--- a/spec/models/king_spec.rb
+++ b/spec/models/king_spec.rb
@@ -39,22 +39,27 @@ RSpec.describe King, type: :model do
     end
 
     it "should return true if king and rook have not moved" do
-      expect(@king.can_castle? @rook).to eq true
+      expect(@king.can_castle? @rook.row, @rook.column).to eq true
     end
 
     it "should return false if king has already moved" do
       @king.move_to(8,4)
-      expect(@king.can_castle? @rook).to eq false
+      expect(@king.can_castle? @rook.row, @rook.column).to eq false
     end
 
     it "should return false if rook has already moved" do
       @rook.move_to(8,2)
-      expect(@king.can_castle? @rook).to eq false
+      expect(@king.can_castle? @rook.row, @rook.column).to eq false
     end
 
     it "should return false if a piece is between the king and rook" do
       obstructing_piece = FactoryGirl.create(:knight, game_id: @game.id, row: 8, column: 2)
-      expect(@king.can_castle? @rook).to eq false
+      expect(@king.can_castle? @rook.row, @rook.column).to eq false
+    end
+
+    it "shoudl return false if no piece is at rook start" do
+      @rook.update_attributes(row: 5, column: 5)
+      expect(@king.can_castle? 8, 1).to eq false
     end
   end
 end

--- a/spec/models/king_spec.rb
+++ b/spec/models/king_spec.rb
@@ -29,6 +29,14 @@ RSpec.describe King, type: :model do
 
       expect(king.valid_move?(7,5)).to eq false
     end
+
+    it 'should return true if the king can make a valid castle move' do
+      game = FactoryGirl.create(:game)
+      king = FactoryGirl.create(:king, game_id: game.id, row: 8, column: 5)
+      rook = FactoryGirl.create(:rook, game_id: game.id, row: 8, column: 1)
+
+      expect(king.valid_move?(8,1)).to eq true
+    end
   end
 
   describe "can_castle?()" do

--- a/spec/models/knight_spec.rb
+++ b/spec/models/knight_spec.rb
@@ -2,32 +2,31 @@ require 'rails_helper'
 
 RSpec.describe Knight, type: :model do
   describe 'valid_move?' do
+    before :each do
+      @game = FactoryGirl.create(:game)
+      @knight = FactoryGirl.create(:knight, game_id: @game.id)
+    end
+
     it 'should return true if piece moves in 2-1 L shape' do
-      knight = FactoryGirl.create(:knight)
-      expect(knight.valid_move?(3,2)).to eq true
+      expect(@knight.valid_move?(3,2)).to eq true
     end
 
     it 'should return true if piece moves in 2-1 L shape backwards' do
-      knight = FactoryGirl.create(:knight, row: 4, column: 4)
-      expect(knight.valid_move?(2,3)).to eq true
+      expect(@knight.valid_move?(2,3)).to eq true
     end
 
     it 'should not care about obstructions' do
-      game = FactoryGirl.create(:game)
-      knight = FactoryGirl.create(:knight, game_id: game.id)
-      piece = FactoryGirl.create(:pawn, game_id: game.id, row: 2, column: 1)
+      piece = FactoryGirl.create(:pawn, game_id: @game.id, row: 2, column: 1)
 
-      expect(knight.valid_move?(3,2)).to eq true
+      expect(@knight.valid_move?(3,2)).to eq true
     end
 
     it 'should return false if piece moves any other way' do
-      knight = FactoryGirl.create(:knight)
-      expect(knight.valid_move?(3,3)).to eq false
+      expect(@knight.valid_move?(3,3)).to eq false
     end
 
     it 'should return false if piece is moving in larger 2/1 jumps i.e. 4/2' do
-      knight = FactoryGirl.create(:knight)
-      expect(knight.valid_move?(5,3)).to eq false
+      expect(@knight.valid_move?(5,3)).to eq false
     end
   end
 end


### PR DESCRIPTION
# Castling
PR to implement the ability to castle. The implementation took two steps, creating a method to confirm that castling was valid (can_castle?) and overriding the parent implementation of move_to.

- can_castle? confirms that neither the king or rook have moved, that a rook is present at the specified corner, and confirms that there are no obstructions between king and rook. Technically, this implementation would allow for a castle to happen if a rook is not on it's corner, but also has never moved. Since this is impossible an actual game, this didn't seem to be a big deal.

- In order to facilitate the actual move I overrode the parent move_to method. The method checks again if castling is valid, and if it is, moves the pieces accordingly.  If castling is not valid, the method simply calls super and relies on the logic of the parent method to handle the move.

Let me know what you think.