### PR TITLE
Chuong/keep track of turns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@
 # Ignore all logfiles and tempfiles.
 /log/*.log
 /tmp
+
+# Ignore application configuration
+/config/application.yml

--- a/Gemfile
+++ b/Gemfile
@@ -39,6 +39,8 @@ end
 
 gem 'simple_form'
 gem 'jquery-ui-rails'
+gem 'pusher'
+gem 'figaro'
 
 # Use ActiveModel has_secure_password
 # gem 'bcrypt', '~> 3.1.7'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -57,7 +57,10 @@ GEM
     factory_girl_rails (4.8.0)
       factory_girl (~> 4.8.0)
       railties (>= 3.0.0)
+    figaro (1.1.1)
+      thor (~> 0.14)
     hike (1.2.3)
+    httpclient (2.8.3)
     i18n (0.7.0)
     jbuilder (2.6.1)
       activesupport (>= 3.0.0, < 5.1)
@@ -85,6 +88,11 @@ GEM
     pry-rails (0.3.4)
       pry (>= 0.9.10)
     puma (3.6.2)
+    pusher (1.3.0)
+      httpclient (~> 2.7)
+      multi_json (~> 1.0)
+      pusher-signature (~> 0.1.8)
+    pusher-signature (0.1.8)
     rack (1.5.5)
     rack-test (0.6.3)
       rack (>= 1.0)
@@ -169,12 +177,14 @@ DEPENDENCIES
   coffee-rails (~> 4.0.0)
   devise (>= 3.2.4)
   factory_girl_rails (~> 4.0)
+  figaro
   jbuilder (~> 2.0)
   jquery-rails
   jquery-ui-rails
   pg
   pry-rails
   puma
+  pusher
   rails (= 4.1.9)
   rspec-rails (~> 3.0)
   sass-rails
@@ -186,4 +196,4 @@ DEPENDENCIES
   uglifier (>= 1.3.0)
 
 BUNDLED WITH
-   1.13.6
+   1.14.3

--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -25,8 +25,10 @@ class GamesController < ApplicationController
   def create
     @game = Game.create(game_params)
     if @game.valid?
-      @game.update_attributes(white_player_id: current_player.id)
+      @game.update_attributes(white_player_id: current_player.id,
+                              active_player_id: current_player.id)
       @game.populate_game!
+
       redirect_to game_path(@game)
     else
       render :new, status: :unprocessable_entity

--- a/app/controllers/pieces_controller.rb
+++ b/app/controllers/pieces_controller.rb
@@ -15,16 +15,54 @@ class PiecesController < ApplicationController
   end
 
   def update
-    if current_piece.valid_move?(params[:row].to_i, params[:column].to_i)
+    # check if current_player can make the move
+    # or selects the right piece color
+    # or the move is valid
+    if (current_player.id == active_player.id &&
+        current_piece.is_black == (active_player.id == black_player.id) &&
+        current_piece.valid_move?(params[:row].to_i, params[:column].to_i))
+      # save old position before moving
+      old_row = current_piece.row
+      old_column = current_piece.column
       current_piece.move_to(params[:row], params[:column])
+
+      # swap active player
+      if current_piece.game.active_player == current_piece.game.white_player
+        current_piece.game.update_attributes(active_player: current_piece.game.black_player)
+      else
+        current_piece.game.update_attributes(active_player: current_piece.game.white_player)
+      end
+
+      # inform of successful move
+      channel_name = 'game_channel_' + current_piece.game.id.to_s
+      puts channel_name
+      Pusher['game_channel_' + current_piece.game.id.to_s].trigger('move', {
+        :old_row => old_row, :old_column => old_row,
+        :new_row => params[:row], :new_column => params[:column],
+        :piece_id => current_piece.id
+      })
       render json: current_piece
+    else
+      render json: {}
     end
   end
 
   private
 
     def current_piece
-      @piece ||= Piece.find(params[:id])
+      @current_piece ||= Piece.find(params[:id])
+    end
+
+    def current_player
+      @current_player ||= Player.find(params[:current_player_id])
+    end
+
+    def active_player
+      @active_player ||= Player.find(current_piece.game.active_player_id)
+    end
+
+    def black_player
+      @black_player ||= current_piece.game.black_player
     end
 
     def is_actual_move?(row_destination, col_destination)

--- a/app/controllers/pieces_controller.rb
+++ b/app/controllers/pieces_controller.rb
@@ -26,9 +26,10 @@ class PiecesController < ApplicationController
       old_column = current_piece.column
       # Update the pieces row / column pair
       current_piece.move_to(params[:row], params[:column])
+
       # Update the pieces type if it is promotable
       current_piece.promote(params[:new_type]) if current_piece.is_promotable?
-      
+
       # swap active player
       if current_piece.game.active_player == current_piece.game.white_player
         current_piece.game.update_attributes(active_player: current_piece.game.black_player)
@@ -38,7 +39,6 @@ class PiecesController < ApplicationController
 
       # inform of successful move
       channel_name = 'game_channel_' + current_piece.game.id.to_s
-      puts channel_name
       Pusher['game_channel_' + current_piece.game.id.to_s].trigger('move', {
         :old_row => old_row, :old_column => old_row,
         :new_row => params[:row], :new_column => params[:column],

--- a/app/helpers/games_helper.rb
+++ b/app/helpers/games_helper.rb
@@ -24,7 +24,7 @@ module GamesHelper
     content_tag(
       :td,
       content_tag(:div, raw(select_html_symbol(piece)), data: { 'piece-color' => piece_color(piece) },
-      class: 'contains-piece', id: piece.id),
+      class: 'contains-piece', id: "piece-#{piece.id}"),
       class: square_color(row, col),
       id: "square-#{row}-#{col}",
     )

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -3,6 +3,7 @@ class Game < ActiveRecord::Base
   has_many :pieces
   belongs_to :white_player, class_name: 'Player'
   belongs_to :black_player, class_name: 'Player'
+  belongs_to :active_player, class_name: 'Player'
 
   def populate_game!
     8.times do |n|

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -7,7 +7,8 @@
   <body>
     <div class="col-xs-12 col-sm-10 col-sm-offset-1">
       <div class="col-xs-10">
-        <table class="table chessboard text-center">
+        <table class="table chessboard text-center"
+        game_id=<%= @game.id%> current_player_id=<%= current_player.id%> >
           <% 8.downto(1).each do |row| %>
             <tr id="row-<%= row %>" class="row">
               <td class="coordinate"><%= row %></td>
@@ -33,6 +34,7 @@
   </body>
 </html>
 
+<script src="//js.pusher.com/2.2/pusher.min.js"></script>
 <script>
 $(function() {
   // set layer position of pieces and hovering cursor shape
@@ -47,30 +49,47 @@ $(function() {
     // FIXME: This function does not check for valid move.
     //        It does not update database.
     drop: function(event, ui){
-      // get selected piece's and square's attributes
+      // get selected piece's and square's attributes, and current player id
       let piece_div = ui.draggable;
       let square_div = $(this);
       var piece_id = piece_div.attr('id');
+      var piece_info = piece_id.split('-');
       var square_id = square_div.attr('id');
       var square_info = square_id.split('-');
+      var current_player_id = $('.chessboard').attr('current_player_id')
 
       // try update the piece to the new location
-      $.post("/pieces/" + piece_id, {
+      $.post("/pieces/" + piece_info[1], {
         _method: "PUT",
         row: square_info[1],
-        column: square_info[2]
-      }).success(function(data) {
-        // upon successful move, clear the destination square
-        if (square_div.text().length != 0) {
-          square_div.children().hide('slow');
-          square_div.empty();
-        }
-        // and add the piece in
-        square_div.append(piece_div);
+        column: square_info[2],
+        current_player_id: current_player_id
       });
       // reset the piece position relative to the square
       piece_div.css({left: 0, top: 0});
     }
+  });
+
+  // Add pusher event listening
+  var pusher = new Pusher('<%= Pusher.key %>'); // uses your APP KEY
+  var game_id = $('.chessboard').attr('game_id')
+  console.log('game_channel_' + game_id)
+  var channel = pusher.subscribe('game_channel_' + game_id);
+  channel.bind('move', function(data) {
+    console.log(data);
+    var old_square_id = '#square-' + data.old_row + '-' + data.old_column;
+    var new_square_id = '#square-' + data.new_row + '-' + data.new_column;
+    var piece_id = '#piece-' + data.piece_id;
+    var old_square_div = $(old_square_id);
+    var new_square_div = $(new_square_id);
+    var piece_div = $(piece_id);
+
+    if (new_square_div.text().length != 0) {
+      new_square_div.children().hide('slow');
+      new_square_div.empty();
+    }
+    // and add the piece in
+    new_square_div.append(piece_div);
   });
 
 });

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,3 +1,9 @@
+require 'pusher'
+
+Pusher.app_id = ENV['PUSHER_KEY_ID']
+Pusher.key    = ENV['PUSHER_KEY']
+Pusher.secret = ENV['PUSHER_SECRET']
+
 Rails.application.configure do
   config.action_mailer.default_url_options = { host: 'localhost', port: 3030 }
   # Settings specified here will take precedence over those in config/application.rb.
@@ -35,4 +41,8 @@ Rails.application.configure do
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
+
+  # Enable more than one request
+  config.allow_concurrency = true
+
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,8 +1,10 @@
 require 'pusher'
 
-Pusher.app_id = ENV['PUSHER_KEY_ID']
+Pusher.app_id = ENV['PUSHER_APP_ID']
 Pusher.key    = ENV['PUSHER_KEY']
 Pusher.secret = ENV['PUSHER_SECRET']
+Pusher.logger = Rails.logger
+Pusher.encrypted = true
 
 Rails.application.configure do
   config.action_mailer.default_url_options = { host: 'localhost', port: 3030 }

--- a/db/migrate/20170206123255_add_active_player_to_games.rb
+++ b/db/migrate/20170206123255_add_active_player_to_games.rb
@@ -1,5 +1,6 @@
 class AddActivePlayerToGames < ActiveRecord::Migration
   def change
     add_column :games, :active_player_id, :integer, class_name: "Player"
+    add_index :games, :active_player_id
   end
 end

--- a/db/migrate/20170206123255_add_active_player_to_games.rb
+++ b/db/migrate/20170206123255_add_active_player_to_games.rb
@@ -1,0 +1,5 @@
+class AddActivePlayerToGames < ActiveRecord::Migration
+  def change
+    add_column :games, :active_player_id, :integer, class_name: "Player"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170130021449) do
+ActiveRecord::Schema.define(version: 20170206123255) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -23,28 +23,11 @@ ActiveRecord::Schema.define(version: 20170130021449) do
     t.string   "result"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.integer  "active_player_id"
   end
 
   add_index "games", ["black_player_id"], name: "index_games_on_black_player_id", using: :btree
   add_index "games", ["white_player_id"], name: "index_games_on_white_player_id", using: :btree
-
-  create_table "identities", force: true do |t|
-    t.integer  "user_id"
-    t.string   "provider"
-    t.string   "accesstoken"
-    t.string   "refreshtoken"
-    t.string   "uid"
-    t.string   "name"
-    t.string   "email"
-    t.string   "nickname"
-    t.string   "image"
-    t.string   "phone"
-    t.string   "urls"
-    t.datetime "created_at"
-    t.datetime "updated_at"
-  end
-
-  add_index "identities", ["user_id"], name: "index_identities_on_user_id", using: :btree
 
   create_table "moves", force: true do |t|
     t.integer  "game_id"
@@ -92,23 +75,5 @@ ActiveRecord::Schema.define(version: 20170130021449) do
 
   add_index "players", ["email"], name: "index_players_on_email", unique: true, using: :btree
   add_index "players", ["reset_password_token"], name: "index_players_on_reset_password_token", unique: true, using: :btree
-
-  create_table "users", force: true do |t|
-    t.string   "email",                  default: "", null: false
-    t.string   "encrypted_password",     default: "", null: false
-    t.string   "reset_password_token"
-    t.datetime "reset_password_sent_at"
-    t.datetime "remember_created_at"
-    t.integer  "sign_in_count",          default: 0,  null: false
-    t.datetime "current_sign_in_at"
-    t.datetime "last_sign_in_at"
-    t.inet     "current_sign_in_ip"
-    t.inet     "last_sign_in_ip"
-    t.datetime "created_at",                          null: false
-    t.datetime "updated_at",                          null: false
-  end
-
-  add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree
-  add_index "users", ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
 
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -26,6 +26,7 @@ ActiveRecord::Schema.define(version: 20170206123255) do
     t.integer  "active_player_id"
   end
 
+  add_index "games", ["active_player_id"], name: "index_games_on_active_player_id", using: :btree
   add_index "games", ["black_player_id"], name: "index_games_on_black_player_id", using: :btree
   add_index "games", ["white_player_id"], name: "index_games_on_white_player_id", using: :btree
 

--- a/spec/controllers/pieces_controller_spec.rb
+++ b/spec/controllers/pieces_controller_spec.rb
@@ -2,40 +2,106 @@ require 'rails_helper'
 
 RSpec.describe PiecesController, type: :controller do
   describe "pieces#update" do
-    it "should update the piece type if is_promotable? returns true" do
-      player = FactoryGirl.create(:player)
-      sign_in player
+    it "should return false when a white player moves a black piece" do
+      white_player = FactoryGirl.create(:player)
+      black_player = FactoryGirl.create(:player)
+      sign_in white_player
+      sign_in black_player
 
-      game = FactoryGirl.create(:game, white_player_id: player.id)
+      game = FactoryGirl.create(:game, white_player_id: white_player.id,
+                                black_player_id: black_player.id,
+                                active_player_id: white_player.id)
+      pawn = FactoryGirl.create(:pawn, is_black: true, game_id: game.id)
+
+      patch :update, id: pawn.id, row: 2, column: 1, current_player_id: white_player.id
+
+      pieces = Piece.where(row: 2, column: 1)
+      expect(pieces.exists?).to eq false
+      expect(pawn.game.active_player_id).to eq white_player.id
+    end
+
+    it "should return false when a non active player makes a move and no change turn" do
+      white_player = FactoryGirl.create(:player)
+      black_player = FactoryGirl.create(:player)
+      sign_in white_player
+      sign_in black_player
+
+      game = FactoryGirl.create(:game, white_player_id: white_player.id,
+                                black_player_id: black_player.id,
+                                active_player_id: white_player.id)
+      pawn = FactoryGirl.create(:pawn, is_black: false, game_id: game.id)
+
+      patch :update, id: pawn.id, row: 2, column: 1, current_player_id: black_player.id
+
+      pieces = Piece.where(row: 2, column: 1)
+      expect(pieces.exists?).to eq false
+      expect(pawn.game.active_player_id).to eq white_player.id
+    end
+
+    it "should return true when a active player makes a move and changes turn" do
+      white_player = FactoryGirl.create(:player)
+      black_player = FactoryGirl.create(:player)
+      sign_in white_player
+      sign_in black_player
+
+      game = FactoryGirl.create(:game, white_player_id: white_player.id,
+                                black_player_id: black_player.id,
+                                active_player_id: white_player.id)
+      pawn = FactoryGirl.create(:pawn, is_black: false, game_id: game.id)
+
+      patch :update, id: pawn.id, row: 2, column: 1, current_player_id: white_player.id
+
+      pieces = Piece.where(row: 2, column: 1)
+      expect(pieces.exists?).to eq true
+      expect(pawn.game.active_player_id).to eq black_player.id
+    end
+
+    it "should update the piece type if is_promotable? returns true" do
+      white_player = FactoryGirl.create(:player)
+      black_player = FactoryGirl.create(:player)
+      sign_in white_player
+      sign_in black_player
+
+      game = FactoryGirl.create(:game, white_player_id: white_player.id,
+                                black_player_id: black_player.id,
+                                active_player_id: white_player.id)
       pawn = FactoryGirl.create(:pawn, row: 7, is_black: false, game_id: game.id)
 
-      patch :update, id: pawn.id, row: 8, column: 1, new_type: 'Rook'
+      patch :update, id: pawn.id, row: 8, column: 1, new_type: 'Rook', current_player_id: white_player.id
 
       piece = Piece.find(pawn.id)
       expect(piece.type).to eq 'Rook'
     end
 
     it "should not update the piece type if is_promotable? returns false" do
-      player = FactoryGirl.create(:player)
-      sign_in player
+      white_player = FactoryGirl.create(:player)
+      black_player = FactoryGirl.create(:player)
+      sign_in white_player
+      sign_in black_player
 
-      game = FactoryGirl.create(:game, white_player_id: player.id)
+      game = FactoryGirl.create(:game, white_player_id: white_player.id,
+                                black_player_id: black_player.id,
+                                active_player_id: white_player.id)
       pawn = FactoryGirl.create(:pawn, row: 6, is_black: false, game_id: game.id)
 
-      patch :update, id: pawn.id, row: 7, column: 1, new_type: 'Rook'
+      patch :update, id: pawn.id, row: 7, column: 1, new_type: 'Rook', current_player_id: white_player.id
 
       piece = Piece.find(pawn.id)
       expect(piece.type).to eq 'Pawn'
     end
 
     it "should not promote a special piece on a promotion row" do
-      player = FactoryGirl.create(:player)
-      sign_in player
+      white_player = FactoryGirl.create(:player)
+      black_player = FactoryGirl.create(:player)
+      sign_in white_player
+      sign_in black_player
 
-      game = FactoryGirl.create(:game, white_player_id: player.id)
+      game = FactoryGirl.create(:game, white_player_id: white_player.id,
+                                black_player_id: black_player.id,
+                                active_player_id: white_player.id)
       rook = FactoryGirl.create(:rook, row: 7, is_black: false, game_id: game.id)
 
-      patch :update, id: rook.id, row: 8, column: 1, new_type: 'Queen'
+      patch :update, id: rook.id, row: 8, column: 1, new_type: 'Queen', current_player_id: white_player.id
 
       piece = Piece.find(rook.id)
       expect(piece.type).to eq 'Rook'


### PR DESCRIPTION
Changes to keep track of player turns and update chessboard with move by remote player:
- Add Pusher gem for remote notification and Figaro to load environment variables.
- Add active player field to Game to keep track of turn.

Please have a look and test it out. I share my `config/application.yml` file for Pusher's settings in our slack channel. You need to log in chess-app from two different user accounts on different browsers or machines to test player turn effect.